### PR TITLE
Add additional api example (wolfram-alpha)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,4 @@ NEWS_API_KEY=your_key_here
 TMDB_API_KEY=your_key_here
 GOOGLE_API_KEY=your_key_here
 GOOGLE_CSE_ID=your_id_here
- 
+WOLFRAM_ALPHA_APPID=your_id_here


### PR DESCRIPTION
It uses wolfram-alpha API-key, but the example didn't have it.